### PR TITLE
Potential fix for code scanning alert no. 4: Application backup allowed

### DIFF
--- a/apps/beekeeperMobile/app/src/main/AndroidManifest.xml
+++ b/apps/beekeeperMobile/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
 
     <application
         android:name=".BeekeeperApp"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Potential fix for [https://github.com/Shraggen/Beekeeper/security/code-scanning/4](https://github.com/Shraggen/Beekeeper/security/code-scanning/4)

To prevent automatic backup of sensitive application data, set the attribute `android:allowBackup="false"` in the `<application>` element in the AndroidManifest.xml file (`apps/beekeeperMobile/app/src/main/AndroidManifest.xml`). This change is non-breaking and only prevents data managed by the app from being backed up by Android’s auto-backup feature, which addresses the security issue flagged by CodeQL. You should add the attribute directly within the open `<application ...>` line (line 12), and avoid changing any other manifest attributes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
